### PR TITLE
Pass specific version to fe_download

### DIFF
--- a/src/FEModels.jl
+++ b/src/FEModels.jl
@@ -10,9 +10,9 @@ using GZip
 
 Download finite element mesh from FEModels repository.
 """
-function fe_download(model, mesh)
-#   url = "https://github.com/JuliaFEM/FEModels/blob/master/$model/$mesh.gz?raw=true"
-    url = "https://raw.githubusercontent.com/JuliaFEM/FEModels/master/$model/$mesh.gz"
+function fe_download(model, mesh, version)
+#   url = "https://github.com/JuliaFEM/FEModels/blob/$version/$model/$mesh.gz?raw=true"
+    url = "https://raw.githubusercontent.com/JuliaFEM/FEModels/$version/$model/$mesh.gz"
     isdir(model) || mkdir(model)
     local_file = joinpath(model, mesh)
     local_file_packed = "$local_file.gz"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,6 @@ using Base.Test
 using FEModels
 
 @testset "download file" begin
-    fn = fe_download("block-and-cylinder", "mesh_sparse.inp")
+    fn = fe_download("block-and-cylinder", "mesh_sparse.inp", "50dbcbbcf4504c1a8746bc2a0655b69de4604276")
     @test isfile(fn)
 end


### PR DESCRIPTION
It's a good idea for reproducibility of tests to always refer to a specific version here, avoid using master since that can change arbitrarily.